### PR TITLE
add CMake build system support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(common "libnmea/src/nmea/nmea.c"
+           "libnmea/src/nmea/parser_static.c"
+           "libnmea/src/parsers/parse.c"
+           )
+
+set(parsers gpgga gpgll gprmc)
+
+idf_component_register(SRCS ${common}
+                       INCLUDE_DIRS "libnmea/src/nmea"
+                                    "libnmea/src/parsers"
+                      )
+
+foreach(parser ${parsers})
+    # add source file
+    set(src_file "libnmea/src/parsers/${parser}.c")
+    target_sources(${COMPONENT_LIB} PRIVATE ${src_file})
+
+    # add some preprocessor definitions to rename the interface functions
+    set(prefix nmea_${parser}_)
+    set(defs "allocate_data=${prefix}allocate_data"
+             "free_data=${prefix}free_data"
+             "init=${prefix}init"
+             "parse=${prefix}parse"
+             "set_default=${prefix}set_default"
+    )
+    set_source_files_properties(${src_file} PROPERTIES COMPILE_DEFINITIONS "${defs}")
+
+    # Hide incorrect (but harmless) use of strncpy in NMEA_PARSER_PREFIX macro
+    set_source_files_properties(${src_file} PROPERTIES COMPILE_OPTIONS "-Wno-stringop-truncation")
+
+    # Enable the parser
+    string(TOUPPER ${parser} parser_uppercase)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE "ENABLE_${parser_uppercase}=1")
+endforeach()
+
+list(LENGTH parsers parsers_count)
+target_compile_definitions(${COMPONENT_LIB} PRIVATE PARSER_COUNT=${parsers_count})

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+
+# add libnmea component from the top level directory
+set(EXTRA_COMPONENT_DIRS "../")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(nmea_example)

--- a/example/main/CMakeLists.txt
+++ b/example/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "nmea_example_main.c"
+                       INCLUDE_DIRS ".")


### PR DESCRIPTION
This PR adds ESP-IDF CMake build system support.

Note that latest upstream libnmea library comes with CMakeLists.txt file, so theoretically we could simplify the component CMakeLists.txt file to set the correct options/flags and call `add_subdirectory`. I'll do this next time I update libnmea submodule to the latest upstream version.

Currently there are 2 warnings in libnmea submodule:

* stringop-truncation warning due to the use of strncpy in `NMEA_PARSER_PREFIX` macro. The compiler is correct, but the warning is actually harmless. The proper fix would be to replace strncpy with memcpy in the upstream project. Will open a PR later. For now, the warning is silenced in component CMakeLists.txt.
* Redefinition of `_XOPEN_SOURCE` macro in parse.h. No workaround possible, needs to be fixed in upstream by guarding this line if `#ifndef _XOPEN_SOURCE` ... `#endif`. Will open a PR upstream as well.

Tested to compile with ESP-IDF master branch. I don't have a GPS module at hand, so haven't verified if the example works.

Closes #2