### PR TITLE
Lower CMake required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 set(common "libnmea/src/nmea/nmea.c"
            "libnmea/src/nmea/parser_static.c"


### PR DESCRIPTION
CMake v3.5 is supported by ESP-IDF and this component compiles just fine with it.
(the underlaying `libnmea` requires v2.8)