### PR TITLE
Add -Wno-strict-prototypes compile flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ endforeach()
 
 list(LENGTH parsers parsers_count)
 target_compile_definitions(${COMPONENT_TARGET} PRIVATE PARSER_COUNT=${parsers_count})
+target_compile_options(${COMPONENT_TARGET} PRIVATE "-Wno-strict-prototypes")
 
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "4.0")
     set_source_files_properties(libnmea/src/parsers/gpgsa.c PROPERTIES COMPILE_OPTIONS "-Wno-char-subscripts")

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ This is a wrapper around [libnmea](https://github.com/jacketizer/libnmea),
 in the form of an [ESP-IDF](https://github.com/espressif/esp-idf) component.
 It works with any chip supported in ESP-IDF: ESP32, ESP32-S2, ESP32-S3, ESP32-C3.
 
-To use, clone the component into the `components` directory of your project,
+## Usage
+
+There are two usage options:
+
+1. Use [idf-component-manager](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html). Simply run `idf.py add-dependency igrr/libnmea==required_version` in your project directory.
+
+OR
+
+2. Clone the component into the `components` directory of your project,
 or add it as a submodule.
 See [libnmea documentation](https://github.com/jacketizer/libnmea#how-to-use-it)
 for more details.

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "0.1.1"
 description: NMEA parser
 url: https://github.com/igrr/libnmea-esp32
 dependencies:


### PR DESCRIPTION
In ESP-IDF CI we compile with `-Wstrict-prototypes` which prevents us from including this component in the CI tests.

This PR adds  -Wno-strict-prototypes compile flag, to mitigate this issue.

Readme updated to endorse idf-component-manager